### PR TITLE
Fixed warnings

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -4012,7 +4012,6 @@ definitions:
     - type: object
       properties:
         data:
-          type: object
           default: null
 
 
@@ -5312,6 +5311,7 @@ definitions:
     required:
       - termUids
       - authorization
+    type: object
     properties:
       termUids:
         type: array
@@ -5321,6 +5321,7 @@ definitions:
       authorization:
         required:
           - localeWorkflows
+        type: object
         properties:
           localeWorkflows:
             type: array
@@ -5371,6 +5372,7 @@ definitions:
       - name
       - description
       - sourceLocaleId
+    type: object
     properties:
       name:
         type: string
@@ -5387,9 +5389,11 @@ definitions:
     - $ref: '#/definitions/CreateGlossary'
 
   CreateTerm:
+    type: object
     allOf:
     - $ref: '#/definitions/TermData'
   UpdateTerm:
+    type: object
     allOf:
     - $ref: '#/definitions/TermData'
 


### PR DESCRIPTION
All definitions must have types for proper documentation generation.