### PR TITLE
DOCS-818: update file types

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -985,7 +985,7 @@ paths:
           required: false
           type: boolean
           description: |
-            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for gettext, Java properties, custom XML, and JSON files.
+            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for Android XML, gettext, Java properties, custom XML, and JSON files.
 
             | Value | Description |
             |-------|-------------|
@@ -1057,7 +1057,7 @@ paths:
           required: false
           type: boolean
           description: |
-            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for gettext, Java properties, custom XML, and JSON files.
+            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for Android XML, gettext, Java properties, custom XML, and JSON files.
 
             | Value | Description |
             |-------|-------------|
@@ -1151,7 +1151,7 @@ paths:
           required: false
           type: boolean
           description: |
-            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for gettext, Java properties, custom XML, and JSON files.
+            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for Android XML, gettext, Java properties, custom XML, and JSON files.
 
             | Value | Description |
             |-------|-------------|
@@ -1684,7 +1684,7 @@ paths:
           required: false
           type: boolean
           description: |
-            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for gettext, Java properties, custom XML, and JSON files.
+            Specifies whether Smartling will return the original string or an empty string where no translation is available. This parameter is only supported for Android XML, gettext, Java properties, custom XML, and JSON files.
 
             | Value | Description |
             |-------|-------------|


### PR DESCRIPTION
As per Andrew S. - added Android XML to list of file types that support the includeOriginalStrings parameter