### PR TITLE
Fix swagger spec syntax errors that prevent it from generating Java c…

### DIFF
--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -7290,8 +7290,8 @@ definitions:
     - type: object
       properties:
         data:
-          default: null
           type: object
+          description: Always null.
 
 
   AuthenticationRequest:

--- a/spec/swagger.yaml
+++ b/spec/swagger.yaml
@@ -1358,6 +1358,8 @@ paths:
 
       tags:
         - Files
+      consumes:
+        - multipart/form-data
       parameters:
         - name: projectId
           in: path
@@ -1406,6 +1408,8 @@ paths:
 
       tags:
         - Files
+      consumes:
+        - multipart/form-data
       parameters:
         - name: projectId
           in: path
@@ -3631,6 +3635,7 @@ paths:
                     instruction:
                       description: |-
                         Creates an instruction that is displayed to translators in the Smartling Translation Interface.
+                      type: string
                     maxLength:
                       description: |-
                         Set the maximum character length recommended for this string and its translations.  Not specifying or setting to 'null' implies no maxLength and on update will remove any existing maxLegnth.
@@ -7286,6 +7291,7 @@ definitions:
       properties:
         data:
           default: null
+          type: object
 
 
   AuthenticationRequest:
@@ -7321,6 +7327,7 @@ definitions:
         type: string
       refreshToken:
         description: A kind of token that can be used to obtain a renewed access token.
+        type: string
       expiresIn:
         description: TTL (time-to-live) in seconds for the access token.
         type: integer
@@ -8755,9 +8762,9 @@ definitions:
             items:
               type: array
               items:
-                $ref: '#/definitions/String'
+                $ref: '#/definitions/StringInfo'
 
-  String:
+  StringInfo:
     description: Information on string
     type: object
     properties:
@@ -9601,6 +9608,7 @@ definitions:
               type: string
             callbackMethod:
               description: The http method (GET|POST) to use when Smartling invokes the callback URL upon job completion.
+              type: string
             createdDate:
               description: The UTC value of the date the job was created.
               type: string
@@ -9718,6 +9726,7 @@ definitions:
               type: string
             callbackMethod:
               description: The http method (GET|POST) to use when Smartling invokes the callback URL upon job completion.
+              type: string
             createdDate:
               description: The UTC value of the date the job was created.
               type: string


### PR DESCRIPTION
…lient
It adds missing properties to specification: types, consumes directive and renames `String` type to avoid conflict in Java