### PR TITLE
Add string instructions to List all source strings

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -14436,6 +14436,26 @@ components:
         maxLength:
           description: Maximum character length
           type: number
+        stringInstructions:
+          description: >-
+            String instructions that were added to the string in the Dashboard.
+          items:
+            description: The text of the instruction.
+            type: string
+          type: array
+        contentFileStringInstructions:
+          description: >-
+            String instructions that were included in the uploaded file if any.
+          items:
+            properties:
+              fileUri:
+                description: URI of the file that contained the instruction.
+                type: string
+              contentFileStringInstruction:
+                description: The text of the instruction.
+                type: string
+            type: object
+          type: array
       type: object
     StringResponse:
       type: object


### PR DESCRIPTION
Add string instructions to the response definition for the
'List all source strings' endpoint.