### PR TITLE
remove-static-list-of-supported-files

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -108,26 +108,7 @@ tags:
       you upload a file to Smartling, it gets parsed into strings, which will
       then be sent into the translation queue.
 
-      **List of Supported File Types and Directives**:
-
-      * [Android XML](https://help.smartling.com/hc/en-us/articles/360008000573)
-      * [CSV](https://help.smartling.com/hc/en-us/articles/360008000593)
-      * [Gettext PO/POT](https://help.smartling.com/hc/en-us/articles/360007894594)
-      * [HTML](https://help.smartling.com/hc/en-us/articles/360007894614)
-      * [InDesign](https://help.smartling.com/hc/en-us/articles/360007894634)
-      * [iOS Strings](https://help.smartling.com/hc/en-us/articles/360008000693)
-      * [iOS Stringsdict](https://help.smartling.com/hc/en-us/articles/360008000713)
-      * [Java Property Files](https://help.smartling.com/hc/en-us/articles/360007894714)
-      * [JSON](https://help.smartling.com/hc/en-us/articles/360008000733)
-      * [MadCap Lingo ZIP Package](https://help.smartling.com/hc/en-us/articles/360008000793)
-      * [Microsoft Office](https://help.smartling.com/hc/en-us/articles/360007894774)
-      * [Plain Text](https://help.smartling.com/hc/en-us/articles/360007894794)
-      * [QT Linguist](https://help.smartling.com/hc/en-us/articles/360007894814)
-      * [RESX](https://help.smartling.com/hc/en-us/articles/360008000833)
-      * [SubRip SRT](https://help.smartling.com/hc/en-us/articles/360007894874)
-      * [XLIFF](https://help.smartling.com/hc/en-us/articles/360007894894)
-      * [XML](https://help.smartling.com/hc/en-us/articles/360008000893)
-      * [YAML](https://help.smartling.com/hc/en-us/articles/360007894934)
+      The complete list of supported file types is available [here](https://help.smartling.com/hc/en-us/articles/360007998893). For information on file directives, please refer to the documentation for each specific file type.
 
   - name: Machine Translation (MT)
     description: |-


### PR DESCRIPTION
https://smartling.atlassian.net/browse/DOCS-1511 

Removed static list of file types and replaced with a link to HC article. Added point about directives. 