### PR TITLE
add-created-date-to-response

### DIFF
--- a/spec/openapi.yaml
+++ b/spec/openapi.yaml
@@ -926,6 +926,7 @@ paths:
                             firstName: user first name 1
                             lastName: user last name 1
                             profileImage: https://my.gravatar.net/avatar/eeca2d632c1weeeaf5dsd3e32e32ddsasd
+                            createdDate: 1704110400000
                         totalCount: 1
         400:
           $ref: '#/components/responses/Error400ResponseDefinition'


### PR DESCRIPTION
https://smartling.atlassian.net/browse/DOCS-1155 

-What Eric noted does not align with the current response body returned. Added "createdDate" value to response to ensure docs match current response format. 

example response 
```
{
    "response": {
        "code": "SUCCESS",
        "data": {
            "totalCount": 1,
            "items": [
                {
                    "userUid": "02e3ac2d81d7",
                    "firstName": "Heidi",
                    "lastName": "Test TRM",
                    "profileImage": "https://secure.gravatar.com/avatar/5216369eca6476360bceae35ca5877e6",
                    "createdDate": 1641241551000
                }
            ]
        }
    }
}
```